### PR TITLE
Fixed mismatched support library versions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ def AAVersion = '4.0.0'
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:appcompat-v7:${rootProject.ext.androidSupportSdkVersion}"
-    compile 'com.android.support:design:23.3.0'
+    compile "com.android.support:design:${rootProject.ext.androidSupportSdkVersion}"
     compile 'com.github.dexafree:materiallist:3.0.1'
     compile 'com.jakewharton.timber:timber:4.5.1'
     compile project(':dlib')


### PR DESCRIPTION
One of the support library imports isn't referencing the `rootProject` scoped `androidSupportSdkVersion` variable, and the support library versions have diverged. This seems like the cause of issue https://github.com/tzutalin/dlib-android-app/issues/27 (a commenter seems to have fixed it another way, but that fix doesn't work for me).